### PR TITLE
Ignores vendor directory and rbenv related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 Gemfile.lock
 pkg/*
+vendor/
 
 # Generated files.
 *.rex.rb
@@ -12,3 +13,6 @@ pkg/*
 \#*\#
 *~
 *.bak
+
+# rbenv
+.ruby-version


### PR DESCRIPTION
Hello,

I followed the steps in README.md to [install nasl as a regular user with Bundler](https://github.com/tenable/nasl/blob/05926b6f2e00f73d253dce4a6e5f75d68586640f/README.md#development). I found out that the `vendor` directory created as a result is not ignored by Git.

Additionally, if you have a local Ruby environment configured with [rbenv](https://github.com/rbenv/rbenv) we should also ignore `.ruby-version`.

This pull request addresses both issues.

Thanks!